### PR TITLE
Add scripts to package data in tar files for each scene

### DIFF
--- a/scripts/bin/tar_derived_data
+++ b/scripts/bin/tar_derived_data
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+scene_dir=${PWD##*/}
+echo "Creating a tar.gz for only the derived data of this scene " $scene_dir
+
+cd ..
+tar --exclude='*resized_images*' --exclude='*log*' -zcvf "$scene_dir"-labeled.tar.gz $scene_dir
+cd $scene_dir
+
+
+

--- a/scripts/bin/tar_raw_log
+++ b/scripts/bin/tar_raw_log
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+scene_dir=${PWD##*/}
+echo "Creating a tar.gz for only the raw logs (both trimmed and untrimmed) of this scene " $scene_dir
+
+cd ..
+tar -zcvf "$scene_dir"-log.tar.gz $scene_dir/*log*
+cd $scene_dir
+
+
+


### PR DESCRIPTION
Don't merge yet -- just flagging this as coming soon

So far:

1) Script, called from a scene_dir, which tars only the derived labeled data for that scene
2) Script, called from a scene_dir, which tars only the raw log from a scene

Obviously missing a script to just iterate over all scenes, but the above are building blocks

Outstanding issue:
- *.ply and *.jlp/freiburg are making their way into the raw log one due to the file names.  Should be changed

Once I fix the above will push to our data server, and provide scripts to iteratively download subsets of scenes